### PR TITLE
Fix Generators

### DIFF
--- a/lib/generators/snfoil/all/all_generator.rb
+++ b/lib/generators/snfoil/all/all_generator.rb
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module Snfoil
+module SnFoil
   class AllGenerator < ::Rails::Generators::Base
+    def self.base_name
+      'snfoil'
+    end
+
+    namespace 'snfoil:all'
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/all/all_generator.rb
+++ b/lib/generators/snfoil/all/all_generator.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 module SnFoil
-  class AllGenerator < Rails::Generators::Base
+  class AllGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/all/all_generator.rb
+++ b/lib/generators/snfoil/all/all_generator.rb
@@ -24,6 +24,8 @@ module Snfoil
     class_option(:skip_model, desc: 'Skip Model Creation', type: :boolean, default: false)
 
     def add_model
+      return if options[:skip_model]
+
       rails_command "generate model #{call_args.join(' ')}", call_options
     end
 

--- a/lib/generators/snfoil/all/all_generator.rb
+++ b/lib/generators/snfoil/all/all_generator.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module SnFoil
+module Snfoil
   class AllGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 

--- a/lib/generators/snfoil/context/context_generator.rb
+++ b/lib/generators/snfoil/context/context_generator.rb
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module Snfoil
+module SnFoil
   class ContextGenerator < ::Rails::Generators::Base
+    def self.base_name
+      'snfoil'
+    end
+
+    namespace 'snfoil:context'
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/context/context_generator.rb
+++ b/lib/generators/snfoil/context/context_generator.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module SnFoil
+module Snfoil
   class ContextGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 

--- a/lib/generators/snfoil/context/context_generator.rb
+++ b/lib/generators/snfoil/context/context_generator.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 module SnFoil
-  class ContextGenerator < Rails::Generators::Base
+  class ContextGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/controller/controller_generator.rb
+++ b/lib/generators/snfoil/controller/controller_generator.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module SnFoil
+module Snfoil
   class ControllerGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 

--- a/lib/generators/snfoil/controller/controller_generator.rb
+++ b/lib/generators/snfoil/controller/controller_generator.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 module SnFoil
-  class ControllerGenerator < Rails::Generators::Base
+  class ControllerGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/controller/controller_generator.rb
+++ b/lib/generators/snfoil/controller/controller_generator.rb
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module Snfoil
+module SnFoil
   class ControllerGenerator < ::Rails::Generators::Base
+    def self.base_name
+      'snfoil'
+    end
+
+    namespace 'snfoil:controller'
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/jsonapi_deserializer/jsonapi_deserializer_generator.rb
+++ b/lib/generators/snfoil/jsonapi_deserializer/jsonapi_deserializer_generator.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module SnFoil
+module Snfoil
   class JsonapiDeserializerGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 

--- a/lib/generators/snfoil/jsonapi_deserializer/jsonapi_deserializer_generator.rb
+++ b/lib/generators/snfoil/jsonapi_deserializer/jsonapi_deserializer_generator.rb
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module Snfoil
+module SnFoil
   class JsonapiDeserializerGenerator < ::Rails::Generators::Base
+    def self.base_name
+      'snfoil'
+    end
+
+    namespace 'snfoil:jsonapi_deserializer'
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/jsonapi_deserializer/jsonapi_deserializer_generator.rb
+++ b/lib/generators/snfoil/jsonapi_deserializer/jsonapi_deserializer_generator.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 module SnFoil
-  class JsonapiDeserializerGenerator < Rails::Generators::Base
+  class JsonapiDeserializerGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/jsonapi_serializer/jsonapi_serializer_generator.rb
+++ b/lib/generators/snfoil/jsonapi_serializer/jsonapi_serializer_generator.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module SnFoil
+module Snfoil
   class JsonapiSerializerGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 

--- a/lib/generators/snfoil/jsonapi_serializer/jsonapi_serializer_generator.rb
+++ b/lib/generators/snfoil/jsonapi_serializer/jsonapi_serializer_generator.rb
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module Snfoil
+module SnFoil
   class JsonapiSerializerGenerator < ::Rails::Generators::Base
+    def self.base_name
+      'snfoil'
+    end
+
+    namespace 'snfoil:jsonapi_serializer'
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/jsonapi_serializer/jsonapi_serializer_generator.rb
+++ b/lib/generators/snfoil/jsonapi_serializer/jsonapi_serializer_generator.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 module SnFoil
-  class JsonapiSerializerGenerator < Rails::Generators::Base
+  class JsonapiSerializerGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/policy/policy_generator.rb
+++ b/lib/generators/snfoil/policy/policy_generator.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module SnFoil
+module Snfoil
   class PolicyGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 

--- a/lib/generators/snfoil/policy/policy_generator.rb
+++ b/lib/generators/snfoil/policy/policy_generator.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 module SnFoil
-  class PolicyGenerator < Rails::Generators::Base
+  class PolicyGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/policy/policy_generator.rb
+++ b/lib/generators/snfoil/policy/policy_generator.rb
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module Snfoil
+module SnFoil
   class PolicyGenerator < ::Rails::Generators::Base
+    def self.base_name
+      'snfoil'
+    end
+
+    namespace 'snfoil:policy'
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/searcher/searcher_generator.rb
+++ b/lib/generators/snfoil/searcher/searcher_generator.rb
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 module SnFoil
-  class SearcherGenerator < Rails::Generators::Base
+  class SearcherGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/searcher/searcher_generator.rb
+++ b/lib/generators/snfoil/searcher/searcher_generator.rb
@@ -14,8 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module Snfoil
+module SnFoil
   class SearcherGenerator < ::Rails::Generators::Base
+    def self.base_name
+      'snfoil'
+    end
+
+    namespace 'snfoil:searcher'
     source_root File.expand_path('templates', __dir__)
 
     argument :model, type: :string

--- a/lib/generators/snfoil/searcher/searcher_generator.rb
+++ b/lib/generators/snfoil/searcher/searcher_generator.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-module SnFoil
+module Snfoil
   class SearcherGenerator < ::Rails::Generators::Base
     source_root File.expand_path('templates', __dir__)
 

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Person < ApplicationRecord
-  has_many :animals
+  has_many :animals, dependent: :destroy
 end


### PR DESCRIPTION
On a Rails project using snfoil-rails 1.1.1 if you run `bundle exec rails generate --help` it doesn't output anything for snfoil. If you correct the namespace (first commit in this PR) you do get an output, but the commands don't work.

```
bundle exec rails generate --help

SnFoil:
  sn_foil:all
  sn_foil:context
  sn_foil:controller
  sn_foil:jsonapi_deserializer
  sn_foil:jsonapi_serializer
  sn_foil:policy
  sn_foil:searcher

bundle exec rails generate sn_foil:all User
Could not find generator 'sn_foil:all'. (Rails::Command::CorrectableNameError)
Did you mean?  sn_foil:controller
Run `bin/rails generate --help` for more options.
```

This is because the module name of `SnFoil` makes Rails believe it should be `sn_foil` for the directory structure (I believe). This also doesn't match the documentation, which believes it would be `rails generate snfoil:all` for example. 

Changing the module name for the generators from `SnFoil` to `Snfoil` seems to resolve this issue, changing the directory structure may work as well. (`/snfoil` to `/sn_foil`). Wasn't sure which you'd prefer.

Additionally the skip model option didn't actually seem to be used? Unless it's used in one of the other dependencies.

Output after changes:

```
bundle exec rails generate --help

Snfoil:
  snfoil:all
  snfoil:context
  snfoil:controller
  snfoil:jsonapi_deserializer
  snfoil:jsonapi_serializer
  snfoil:policy
  snfoil:searcher

bundle exec rails generate snfoil:all User

       rails  generate model User
      invoke  active_record
      create    db/migrate/20250611134312_create_users.rb
      create    app/models/user.rb
      invoke    rspec
      create      spec/models/user_spec.rb
      invoke      factory_bot
      create        spec/factories/users.rb
       rails  generate snfoil:policy User
      create  app/policies/user_policy.rb
       rails  generate snfoil:searcher User
      create  app/searchers/users_searcher.rb
       rails  generate snfoil:context User
      create  app/contexts/user_context.rb
       rails  generate snfoil:jsonapi_serializer User
      create  app/jsonapi_serializers/user_jsonapi_serializer.rb
       rails  generate snfoil:jsonapi_deserializer User
      create  app/jsonapi_deserializers/user_jsonapi_deserializer.rb
       rails  generate snfoil:controller User
      create  app/controllers/users_controller.rb
```

